### PR TITLE
Update declarations to fix warnings in newer dokuwiki

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -110,7 +110,7 @@ class syntax_plugin_cli extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
           case DOKU_LEXER_ENTER :
             $args = substr($match, 4, -1);
@@ -130,7 +130,7 @@ class syntax_plugin_cli extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if($mode == 'xhtml'){
              list($state, $match) = $data;
              switch ($state) {


### PR DESCRIPTION
This plugin works on newer versions of Dokuwiki, (Release 2018-04-22a "Greebo") but generates warnings in the server log:

`FastCGI sent in stderr: "PHP message: PHP Warning:  Declaration of syntax_plugin_cli::handle($match, $state, $pos, &$handler) should be compatible wither $handler) in /var/lib/dokuwiki/lib/plugins/cli/syntax.php on line 0"`